### PR TITLE
Add unit test for `delete-info`

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -287,4 +287,36 @@ mod os_limited {
             _ => panic!("restore_all was expected to return `trash::ErrorKind::RestoreTwins` but did not."),
         }
     }
+
+    #[cfg(all(unix, not(target_os = "macos"), not(target_os = "ios"), not(target_os = "android")))]
+    #[test]
+    #[serial]
+    fn delete_items_info() {
+        init_logging();
+        let names = {
+            let prefix = get_unique_name();
+            let mut names = Vec::with_capacity(5);
+            for n in 0..4 {
+                let name = format!("{prefix}#{n}").into_bytes();
+                names.push(OsString::from_vec(name));
+            }
+
+            // Throw in an invalid UTF-8 OsString for good measure
+            let mut name = OsStr::new(&format!("{prefix}#")).to_os_string().into_encoded_bytes();
+            name.push(168);
+            names.push(OsString::from_vec(name));
+
+            names
+        };
+
+        for name in &names {
+            File::create_new(name).unwrap();
+        }
+
+        let deleted_names = trash::delete_all(&names).unwrap().expect("Should get a list of deleted items");
+        assert_eq!(deleted_names.len(), names.len());
+        for name in names {
+            assert!(deleted_names.iter().any(|item| item.name == name));
+        }
+    }
 }


### PR DESCRIPTION
This branch should be ready to merged upstream after rebasing. I tried rebasing it myself, but GitHub yelled at me so I decided to just implement the unit test instead. There's only small merge conflict with upstream that I can fix after the holidays if I figure out why GitHub doesn't like it.

The ultimate goal is to work on: pop-os/cosmic-files#604